### PR TITLE
Change -SilenceIfNotInWarningOrCriticalState parameter name to -QuietIfOK

### DIFF
--- a/DiskSmartInfo.functions.ps1
+++ b/DiskSmartInfo.functions.ps1
@@ -8,7 +8,8 @@ function Get-DiskSmartInfo
         [CimSession[]]$CimSession,
         [switch]$ShowConvertedData,
         [switch]$CriticalAttributesOnly,
-        [switch]$SilenceIfNotInWarningOrCriticalState
+        [Alias('WarningOrCriticalOnly','SilenceIfNotInWarningOrCriticalState')]
+        [switch]$QuietIfOK
     )
 
     $Script:ErrorCreatingCimSession = @()
@@ -35,7 +36,7 @@ function Get-DiskSmartInfo
                 -Session $cim `
                 -ShowConvertedData:$ShowConvertedData `
                 -CriticalAttributesOnly:$CriticalAttributesOnly `
-                -SilenceIfNotInWarningOrCriticalState:$SilenceIfNotInWarningOrCriticalState
+                -QuietIfOK:$QuietIfOK
             }
         }
         finally
@@ -58,7 +59,7 @@ function Get-DiskSmartInfo
                 -Session $cim `
                 -ShowConvertedData:$ShowConvertedData `
                 -CriticalAttributesOnly:$CriticalAttributesOnly `
-                -SilenceIfNotInWarningOrCriticalState:$SilenceIfNotInWarningOrCriticalState
+                -QuietIfOK:$QuietIfOK
             }
             else
             {
@@ -73,7 +74,7 @@ function Get-DiskSmartInfo
         inGetDiskSmartInfo `
             -ShowConvertedData:$ShowConvertedData `
             -CriticalAttributesOnly:$CriticalAttributesOnly `
-            -SilenceIfNotInWarningOrCriticalState:$SilenceIfNotInWarningOrCriticalState
+            -QuietIfOK:$QuietIfOK
     }
 
     # Error reporting
@@ -97,7 +98,7 @@ function inGetDiskSmartInfo
         [Microsoft.Management.Infrastructure.CimSession[]]$Session,
         [switch]$ShowConvertedData,
         [switch]$CriticalAttributesOnly,
-        [switch]$SilenceIfNotInWarningOrCriticalState
+        [switch]$QuietIfOK
     )
 
     $namespaceWMI = 'root/WMI'
@@ -136,7 +137,7 @@ function inGetDiskSmartInfo
 
     foreach ($diskInfo in $disksInfo)
     {
-        $Silence = $SilenceIfNotInWarningOrCriticalState
+        $Silence = $QuietIfOK
 
         $instanceName = $diskInfo.InstanceName
         $smartData = $diskInfo.VendorSpecific
@@ -177,7 +178,7 @@ function inGetDiskSmartInfo
                 $attribute.Add("Worst", $smartData[$a + 4])
                 $attribute.Add("Data", $(inGetAttributeData -smartData $smartData -a $a))
 
-                if ($SilenceIfNotInWarningOrCriticalState)
+                if ($QuietIfOK)
                 {
                     if ( ($smartAttributes.Where{$_.AttributeID -eq $attributeID}.IsCritical -and $attribute.Data) -or
                          ($attribute.Value -le $attribute.Threshold) )

--- a/DiskSmartInfo.psd1
+++ b/DiskSmartInfo.psd1
@@ -4,7 +4,7 @@
 RootModule = 'DiskSmartInfo.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.2'
+ModuleVersion = '1.0.3'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Core', 'Desktop')

--- a/docs/en-us/Get-DiskSmartInfo.md
+++ b/docs/en-us/Get-DiskSmartInfo.md
@@ -15,13 +15,13 @@ Gets disk SMART information
 ### ComputerName (Default)
 ```
 Get-DiskSmartInfo [[-ComputerName] <String[]>] [-ShowConvertedData] [-CriticalAttributesOnly] 
-[-SilenceIfNotInWarningOrCriticalState] [<CommonParameters>]
+[-QuietIfOK] [<CommonParameters>]
 ```
 
 ### CimSession
 ```
 Get-DiskSmartInfo -CimSession <String[]> [-ShowConvertedData] [-CriticalAttributesOnly] 
-[-SilenceIfNotInWarningOrCriticalState] CommonParameters>]
+[-QuietIfOK] CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -100,7 +100,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SilenceIfNotInWarningOrCriticalState
+### -QuietIfOK
 Displays only attributes, whose value is in Warning or Critical state.
 
 If attribute if critical, it is shown, if its Data greater than 0.
@@ -208,7 +208,7 @@ The command gets disk SMART information and displays only critical attributes.
 
 ### Example 4: Silence if not in warning or critical state
 ```powershell
-Get-DiskSmartInfo -SilenceIfNotInWarningOrCriticalState
+Get-DiskSmartInfo -QuietIfOK
 ```
 
 ```
@@ -228,7 +228,7 @@ Disks that does not have attributes with values in such states does not display.
 
 ### Example 5: Silence if critical attributes are not in warning or critical state
 ```powershell
-Get-DiskSmartInfo -CriticalAttributesOnly -SilenceIfNotInWarningOrCriticalState
+Get-DiskSmartInfo -CriticalAttributesOnly -QuietIfOK
 ```
 
 ```

--- a/docs/ru-ru/Get-DiskSmartInfo.md
+++ b/docs/ru-ru/Get-DiskSmartInfo.md
@@ -15,13 +15,13 @@ schema: 2.0.0
 ### ComputerName (Default)
 ```
 Get-DiskSmartInfo [[-ComputerName] <String[]>] [-ShowConvertedData] [-CriticalAttributesOnly] 
-[-SilenceIfNotInWarningOrCriticalState] [<CommonParameters>]
+[-QuietIfOK] [<CommonParameters>]
 ```
 
 ### CimSession
 ```
 Get-DiskSmartInfo -CimSession <String[]> [-ShowConvertedData] [-CriticalAttributesOnly] 
-[-SilenceIfNotInWarningOrCriticalState] CommonParameters>]
+[-QuietIfOK] CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -99,7 +99,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SilenceIfNotInWarningOrCriticalState
+### -QuietIfOK
 Параметр отображает только те атрибуты, чьи значения находятся в состоянии Warning или Critical.
 
 Если атрибут относится к критичным, он отображается, если его значение (Data) больше 0.
@@ -208,7 +208,7 @@ SMARTData:
 
 ### Example 4: Вывод только тех атрибутов, чьи значения находятся в состоянии Warning или Critical
 ```powershell
-Get-DiskSmartInfo -SilenceIfNotInWarningOrCriticalState
+Get-DiskSmartInfo -QuietIfOK
 ```
 
 ```
@@ -229,7 +229,7 @@ SMARTData:
 
 ### Example 5: Вывод только тех критических атрибутов, чьи значения находятся в состоянии Warning или Critical
 ```powershell
-Get-DiskSmartInfo -CriticalAttributesOnly -SilenceIfNotInWarningOrCriticalState
+Get-DiskSmartInfo -CriticalAttributesOnly -QuietIfOK
 ```
 
 ```

--- a/en-us/DiskSmartInfo-help.xml
+++ b/en-us/DiskSmartInfo-help.xml
@@ -273,7 +273,7 @@ Description    : Count of retry of spin start attempts. This attribute stores a 
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>SilenceIfNotInWarningOrCriticalState</maml:name>
+          <maml:name>QuietIfOK</maml:name>
           <maml:description>
             <maml:para>Displays only attributes, whose value is in Warning or Critical state.</maml:para>
             <maml:para>If attribute if critical, it is shown, if its Data greater than 0. If attribute is not critical, it is shown, if its Value is less or equal to its threshold.</maml:para>
@@ -326,7 +326,7 @@ Description    : Count of retry of spin start attempts. This attribute stores a 
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>SilenceIfNotInWarningOrCriticalState</maml:name>
+          <maml:name>QuietIfOK</maml:name>
           <maml:description>
             <maml:para>Displays only attributes, whose value is in Warning or Critical state.</maml:para>
             <maml:para>If attribute if critical, it is shown, if its Data greater than 0. If attribute is not critical, it is shown, if its Value is less or equal to its threshold.</maml:para>
@@ -393,7 +393,7 @@ Description    : Count of retry of spin start attempts. This attribute stores a 
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>SilenceIfNotInWarningOrCriticalState</maml:name>
+        <maml:name>QuietIfOK</maml:name>
         <maml:description>
           <maml:para>Displays only attributes, whose value is in Warning or Critical state.</maml:para>
           <maml:para>If attribute if critical, it is shown, if its Data greater than 0. If attribute is not critical, it is shown, if its Value is less or equal to its threshold.</maml:para>
@@ -516,7 +516,7 @@ SMARTData:
       </command:example>
       <command:example>
         <maml:title>---- Example 4: Silence if not in warning or critical state ----</maml:title>
-        <dev:code>Get-DiskSmartInfo -SilenceIfNotInWarningOrCriticalState
+        <dev:code>Get-DiskSmartInfo -QuietIfOK
 
 Model:        Disk model
 InstanceId:   Disk Instance Id
@@ -535,7 +535,7 @@ SMARTData:
       </command:example>
       <command:example>
         <maml:title>Example 5: Silence if critical attributes are not in warning or critical state</maml:title>
-        <dev:code>Get-DiskSmartInfo -CriticalAttributesOnly -SilenceIfNotInWarningOrCriticalState
+        <dev:code>Get-DiskSmartInfo -CriticalAttributesOnly -QuietIfOK
 
 Model:        Disk model
 InstanceId:   Disk Instance Id

--- a/ru-ru/DiskSmartInfo-help.xml
+++ b/ru-ru/DiskSmartInfo-help.xml
@@ -273,7 +273,7 @@ Description    : Count of retry of spin start attempts. This attribute stores a 
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>SilenceIfNotInWarningOrCriticalState</maml:name>
+          <maml:name>QuietIfOK</maml:name>
           <maml:description>
             <maml:para>Параметр отображает только те атрибуты, чьи значения находятся в состоянии Warning или Critical.</maml:para>
             <maml:para>Если атрибут относится к критичным, он отображается, если его значение (Data) больше 0.</maml:para>
@@ -327,7 +327,7 @@ Description    : Count of retry of spin start attempts. This attribute stores a 
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>SilenceIfNotInWarningOrCriticalState</maml:name>
+          <maml:name>QuietIfOK</maml:name>
           <maml:description>
             <maml:para>Параметр отображает только те атрибуты, чьи значения находятся в состоянии Warning или Critical.</maml:para>
             <maml:para>Если атрибут относится к критичным, он отображается, если его значение (Data) больше 0.</maml:para>
@@ -395,7 +395,7 @@ Description    : Count of retry of spin start attempts. This attribute stores a 
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>SilenceIfNotInWarningOrCriticalState</maml:name>
+        <maml:name>QuietIfOK</maml:name>
         <maml:description>
           <maml:para>Параметр отображает только те атрибуты, чьи значения находятся в состоянии Warning или Critical.</maml:para>
           <maml:para>Если атрибут относится к критичным, он отображается, если его значение (Data) больше 0.</maml:para>
@@ -519,7 +519,7 @@ SMARTData:
       </command:example>
       <command:example>
         <maml:title>Example 4: Вывод только тех атрибутов, чьи значения находятся в состоянии Warning или Critical</maml:title>
-        <dev:code>Get-DiskSmartInfo -SilenceIfNotInWarningOrCriticalState
+        <dev:code>Get-DiskSmartInfo -QuietIfOK
 
 Model:        Disk model
 InstanceId:   Disk Instance Id
@@ -539,7 +539,7 @@ SMARTData:
       </command:example>
       <command:example>
         <maml:title>Example 5: Вывод только тех критических атрибутов, чьи значения находятся в состоянии Warning или Critical</maml:title>
-        <dev:code>Get-DiskSmartInfo -CriticalAttributesOnly -SilenceIfNotInWarningOrCriticalState
+        <dev:code>Get-DiskSmartInfo -CriticalAttributesOnly -QuietIfOK
 
 Model:        Disk model
 InstanceId:   Disk Instance Id

--- a/tests/DiskSmartInfo.tests.ps1
+++ b/tests/DiskSmartInfo.tests.ps1
@@ -169,12 +169,12 @@ Describe "DiskSmartInfo" {
             }
         }
 
-        Context "-SilenceIfNotInWarningOrCriticalState" {
+        Context "-QuietIfOK" {
             BeforeAll {
                 mock Get-CimInstance -MockWith { $diskInfoHDD1, $diskInfoHDD2, $diskInfoSSD1 } -ParameterFilter { $Namespace -eq $namespaceWMI -and $ClassName -eq $classSMARTData } -ModuleName DiskSmartInfo
                 mock Get-CimInstance -MockWith { $diskThresholdsHDD1, $diskThresholdsHDD2, $diskThresholdsSSD1 } -ParameterFilter { $Namespace -eq $namespaceWMI -and $ClassName -eq $classThresholds } -ModuleName DiskSmartInfo
                 mock Get-CimInstance -MockWith { $diskDriveHDD1, $diskDriveHDD2, $diskDriveSSD1 } -ParameterFilter { $ClassName -eq $classDiskDrive } -ModuleName DiskSmartInfo
-                $diskSmartInfo = Get-DiskSmartInfo -SilenceIfNotInWarningOrCriticalState
+                $diskSmartInfo = Get-DiskSmartInfo -QuietIfOK
             }
 
             It "Has 1 DiskSmartInfo object" {
@@ -193,12 +193,12 @@ Describe "DiskSmartInfo" {
             }
         }
 
-        Context "-CriticalAttributesOnly -SilenceIfNotInWarningOrCriticalState" {
+        Context "-CriticalAttributesOnly -QuietIfOK" {
             BeforeAll {
                 mock Get-CimInstance -MockWith { $diskInfoHDD1, $diskInfoHDD2, $diskInfoSSD1 } -ParameterFilter { $Namespace -eq $namespaceWMI -and $ClassName -eq $classSMARTData } -ModuleName DiskSmartInfo
                 mock Get-CimInstance -MockWith { $diskThresholdsHDD1, $diskThresholdsHDD2, $diskThresholdsSSD1 } -ParameterFilter { $Namespace -eq $namespaceWMI -and $ClassName -eq $classThresholds } -ModuleName DiskSmartInfo
                 mock Get-CimInstance -MockWith { $diskDriveHDD1, $diskDriveHDD2, $diskDriveSSD1 } -ParameterFilter { $ClassName -eq $classDiskDrive } -ModuleName DiskSmartInfo
-                $diskSmartInfo = Get-DiskSmartInfo -CriticalAttributesOnly -SilenceIfNotInWarningOrCriticalState
+                $diskSmartInfo = Get-DiskSmartInfo -CriticalAttributesOnly -QuietIfOK
             }
 
             It "Has 1 DiskSmartInfo object" {


### PR DESCRIPTION
Change `-SilenceIfNotInWarningOrCriticalState` parameter name to `-QuietIfOK`.
`-SilenceIfNotInWarningOrCriticalState` is an alias now.
Add `-WarningOrCriticalOnly` alias.